### PR TITLE
Synopsys: Automated PR: Update log4j:log4j:1.2.17 to 1.2.17.norce

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 		<dependency>
 			<groupId>log4j</groupId>
 			<artifactId>log4j</artifactId>
-			<version>1.2.17</version>
+			<version>1.2.17.norce</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
## Vulnerabilities associated with log4j:log4j:1.2.17
[BDSA-2019-4008](https://openhub.net/vulnerabilities/bdsa/BDSA-2019-4008) *(CRITICAL)*: Apache Log4j is vulnerable to remote code execution (RCE).  This allows a remote attacker to send a crafted serialized payload that, when processed by Log4j, will execute arbitrary code. This can occur if Log4j is deserializing untrusted network traffic.

[BDSA-2021-3764](https://openhub.net/vulnerabilities/bdsa/BDSA-2021-3764) *(HIGH)*: Log4j **1.x** versions are vulnerable to deserializing untrusted data if configured to use `JMSAppender` (which is not the default). A remote attacker could leverage this to execute arbitrary code on the underlying system with the privileges of the application that is running Log4j.

**Note** that Log4j **1.x** has been marked EOL for many years and has not received updates in this time.

[BDSA-2021-4371](https://openhub.net/vulnerabilities/bdsa/BDSA-2021-4371) *(HIGH)*: Apache chainsaw is vulnerable to a deserialization of untrusted data flaw. A remote attacker could leverage this to cause remote code execution (RCE).

[BDSA-2022-0117](https://openhub.net/vulnerabilities/bdsa/BDSA-2022-0117) *(HIGH)*: Log4j is vulnerable to remote code execution (RCE) due to the deserialization of untrusted data. An attacker that is able to make the JMSSink component submit requests to a given LDAP server could load malicious Java classes into the vulnerable application's memory by leveraging the JNDI class-loading capability.

In order to exploit this vulnerability, the attacker must be able to control the configuration of Log4j, or must have access to an LDAP server which the JMSSink component is configured to use. Log4j must also be configured to utilize JMSSink, which is not used by default.

[BDSA-2022-0118](https://openhub.net/vulnerabilities/bdsa/BDSA-2022-0118) *(HIGH)*: Apache Log4j is vulnerable to a remote code execution (RCE) issue due to how the Apache Chainsaw component can unsafely deserialize user controlled input.

An attacker could send crafted input to the application in order to abuse the flaw and execute malicious code on the system.

**Note**: The Apache Chainsaw deserialization vulnerability has been reported as **CVE-2020-9493** and affects EOL Apache Log4j **1.2.x** versions that include this component.

[Click Here To See More Details On Server](https://testing.blackduck.synopsys.com/api/projects/9795f9d3-de82-4087-a1bb-49fd5660b0f2/versions/654f5d9b-9aad-4f05-bb60-9cb037b1eb95/vulnerability-bom?selectedItem=15440247-b0f0-45f7-9a1d-620f41e20e09)