### PR TITLE
Synopsys: Automated PR: Update cn.hutool:hutool-all:5.8.10 to 5.8.32

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
 		<dependency>
 			<groupId>cn.hutool</groupId>
 			<artifactId>hutool-all</artifactId>
-			<version>5.8.10</version>
+			<version>5.8.32</version>
 		</dependency>
 		<dependency>
 		    <groupId>com.itextpdf</groupId>


### PR DESCRIPTION
## Vulnerabilities associated with cn.hutool:hutool-all:5.8.10
[CVE-2023-24162](https://nvd.nist.gov/vuln/detail/CVE-2023-24162) *(CRITICAL)*: Deserialization vulnerability in Dromara Hutool v5.8.11 allows attacker to execute arbitrary code via the XmlUtil.readObjectFromXml parameter.

[CVE-2023-24163](https://nvd.nist.gov/vuln/detail/CVE-2023-24163) *(CRITICAL)*: SQL Inection vulnerability in Dromara hutool before 5.8.21 allows attacker to execute arbitrary code via the aviator template engine.

[CVE-2022-4565](https://nvd.nist.gov/vuln/detail/CVE-2022-4565) *(HIGH)*: A vulnerability classified as problematic was found in Dromara HuTool up to 5.8.10. This vulnerability affects unknown code of the file cn.hutool.core.util.ZipUtil.java. The manipulation leads to resource consumption. The attack can be initiated remotely. The exploit has been disclosed to the public and may be used. Upgrading to version 5.8.11 is able to address this issue. It is recommended to upgrade the affected component. VDB-215974 is the identifier assigned to this vulnerability.

[CVE-2022-45689](https://nvd.nist.gov/vuln/detail/CVE-2022-45689) *(HIGH)*: hutool-json v5.8.10 was discovered to contain an out of memory error.

[CVE-2022-45690](https://nvd.nist.gov/vuln/detail/CVE-2022-45690) *(HIGH)*: A stack overflow in the org.json.JSONTokener.nextValue::JSONTokener.java component of hutool-json v5.8.10 allows attackers to cause a Denial of Service (DoS) via crafted JSON or XML data.

[CVE-2023-33695](https://nvd.nist.gov/vuln/detail/CVE-2023-33695) *(HIGH)*: Hutool v5.8.17 and below was discovered to contain an information disclosure vulnerability via the File.createTempFile() function at /core/io/FileUtil.java.

[Click Here To See More Details On Server](https://testing.blackduck.synopsys.com/api/projects/9795f9d3-de82-4087-a1bb-49fd5660b0f2/versions/3a6b9e8b-44e3-4755-a377-10df19791442/vulnerability-bom?selectedItem=94c0655f-8c25-4653-8926-b8f3cfd1c2a6)