### PR TITLE
Synopsys: Automated PR: Update com.itextpdf:itextpdf:5.5.8 to 5.5.13.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 		<dependency>
 		    <groupId>com.itextpdf</groupId>
 		    <artifactId>itextpdf</artifactId>
-		    <version>5.5.8</version>
+		    <version>5.5.13.4</version>
 		</dependency>
 
 	</dependencies>


### PR DESCRIPTION
## Vulnerabilities associated with com.itextpdf:itextpdf:5.5.8
[BDSA-2017-4082](https://openhub.net/vulnerabilities/bdsa/BDSA-2017-4082) *(HIGH)*: iText is vulnerable to XML External Entities (XXE) attacks due to how the XML parsers in use are not configured to disable external entities.

An attacker could abuse this issue by submitting a crafted PDF file that includes malicious XXE payloads within the XML data of the document in order to perform attacks that can extract files, make forged requests on a server or impact performance.

[BDSA-2017-4117](https://openhub.net/vulnerabilities/bdsa/BDSA-2017-4117) *(HIGH)*: iText RUPS is vulnerable due to improper XML external entity (XXE) handling. A remote attacker could exploit this vulnerability in order to  cause XXE attacks such as local and remote resource inclusion, port scanning and server-side request forgery (SSRF).

**Note:** iText RUPS is no longer supported. The vendor has replaced this product with i7j-RUPS.

[Click Here To See More Details On Server](https://testing.blackduck.synopsys.com/api/projects/9795f9d3-de82-4087-a1bb-49fd5660b0f2/versions/654f5d9b-9aad-4f05-bb60-9cb037b1eb95/vulnerability-bom?selectedItem=c944d452-afd1-4aa6-ba5b-1ab07e46a3a2)