### PR TITLE
Synopsys: Automated PR: Update org.hibernate:hibernate-validator:4.1.0.Final to 5.3.4.Final-redhat-1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 		<dependency>
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-validator</artifactId>
-			<version>4.1.0.Final</version>
+			<version>5.3.4.Final-redhat-1</version>
 		</dependency>
 		<!-- Database -->
 		<dependency>


### PR DESCRIPTION
## Vulnerabilities associated with org.hibernate:hibernate-validator:4.1.0.Final
[BDSA-2019-3481](https://openhub.net/vulnerabilities/bdsa/BDSA-2019-3481) *(MEDIUM)*: Hibernate-Validator is vulnerable to improper sanitization of attacker supplied input. This can result in cross-site scripting (XSS) attacks where some script code could be run on the victim's browser.

[BDSA-2020-1019](https://openhub.net/vulnerabilities/bdsa/BDSA-2020-1019) *(MEDIUM)*: Hibernate Validator is vulnerable to incorrectly validating certain expression language (EL) expressions. A remote attacker could leverage this to bypass input sanitization

[CVE-2014-3558](https://nvd.nist.gov/vuln/detail/CVE-2014-3558) *(MEDIUM)*: ReflectionHelper (org.hibernate.validator.util.ReflectionHelper) in Hibernate Validator 4.1.0 before 4.2.1, 4.3.x before 4.3.2, and 5.x before 5.1.2 allows attackers to bypass Java Security Manager (JSM) restrictions and execute restricted reflection calls via a crafted application.

[Click Here To See More Details On Server](https://testing.blackduck.synopsys.com/api/projects/9795f9d3-de82-4087-a1bb-49fd5660b0f2/versions/654f5d9b-9aad-4f05-bb60-9cb037b1eb95/vulnerability-bom?selectedItem=b3fb71bb-2829-4e19-8010-bda77d41e2ae)